### PR TITLE
Add Codex support and universal routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Claude Code API Router
+# Claude & Codex API Router
 
-A universal HTTP proxy and Python library that automatically routes Anthropic API calls to Claude Code (local inference) when the API key is set to all 9s, otherwise uses the standard Anthropic API.
+A universal HTTP proxy and Python library that automatically routes Anthropic or OpenAI API calls to local CLI tools (Claude Code or Codex) when the API key is set to all 9s, otherwise uses the real cloud APIs.
 
 ## Two Solutions Included
 
 ### 1. Universal HTTP Proxy (Works with ANY language/tool)
-An HTTP/HTTPS proxy server that intercepts all Anthropic API calls from any application, regardless of programming language.
+An HTTP/HTTPS proxy server that intercepts Anthropic or OpenAI API calls from any application, regardless of programming language.
 
 ### 2. Python Library (Python-specific)
 A drop-in replacement for the Anthropic Python client that handles routing internally.
@@ -14,8 +14,8 @@ A drop-in replacement for the Anthropic Python client that handles routing inter
 
 - **Universal Compatibility**: HTTP proxy works with ANY programming language or tool
 - **Transparent Routing**: No code changes needed for existing projects (with proxy)
-- **Claude Code Integration**: Automatically routes to local Claude Code CLI when API key is all 9s
-- **API Compatibility**: Maintains full Anthropic API response format
+- **Claude Code & Codex Integration**: Automatically routes to local Claude Code or Codex CLI when API key is all 9s
+- **API Compatibility**: Maintains Anthropic/OpenAI API response format
 - **Easy Configuration**: Just set your API key to all 9s to enable local routing
 - **Python Library**: Drop-in replacement for Anthropic Python client
 - **Async Support**: Includes both synchronous and asynchronous clients
@@ -26,9 +26,10 @@ A drop-in replacement for the Anthropic Python client that handles routing inter
 pip install -r requirements.txt
 ```
 
-Make sure you have Claude Code CLI installed and available in your PATH:
+Make sure you have the relevant CLI installed and available in your PATH:
 ```bash
-claude --version
+claude --version   # for Claude Code
+codex --version    # for Codex
 ```
 
 ## Quick Start
@@ -41,11 +42,12 @@ python setup_proxy.py  # One-time setup
 ./start_proxy.sh       # Start proxy server
 ```
 
-2. **Configure your environment:**
+2. **Configure your environment (examples):**
 ```bash
 export HTTP_PROXY=http://localhost:8080
 export HTTPS_PROXY=http://localhost:8080
-export ANTHROPIC_API_KEY=999999999999  # All 9s for Claude Code
+export ANTHROPIC_API_KEY=999999999999   # All 9s for Claude Code
+export OPENAI_API_KEY=999999999999      # All 9s for Codex
 ```
 
 3. **Use from ANY language/tool:**
@@ -62,18 +64,19 @@ curl https://api.anthropic.com/v1/messages \
 ```python
 from anthropic_router import create_client
 
-# Use Claude Code (local inference)
-client = create_client(api_key="999999999999")
+# Use Codex locally
+client = create_client(provider="codex", api_key="999999999999")
 
-# Or use the real Anthropic API
-# client = create_client(api_key="sk-ant-api03-your-real-key")
+# Or use Claude Code locally
+# client = create_client(provider="claude", api_key="999999999999")
+
+# Or use cloud providers
+# client = create_client(provider="anthropic", api_key="sk-ant-real-key")
 
 message = client.messages.create(
     model="claude-3-sonnet-20240229",
     max_tokens=100,
-    messages=[
-        {"role": "user", "content": "Hello, how are you?"}
-    ]
+    messages=[{"role": "user", "content": "Hello, how are you?"}]
 )
 
 print(message.content[0].text)

--- a/anthropic_router.py
+++ b/anthropic_router.py
@@ -7,6 +7,7 @@ from anthropic import Anthropic, AsyncAnthropic
 from anthropic.types import Message, MessageParam
 from anthropic._types import NOT_GIVEN, NotGiven
 from claude_code_client import ClaudeCodeClient
+from openai_router import OpenAIRouter
 
 
 class AnthropicRouter:
@@ -170,15 +171,24 @@ class AsyncMessagesRouter:
 
 
 # Convenience function to create a client
-def create_client(api_key: Optional[str] = None) -> AnthropicRouter:
+def create_client(
+    api_key: Optional[str] = None,
+    provider: Optional[str] = None,
+    default_provider: str = "claude",
+) -> Any:
     """
-    Create an Anthropic client that automatically routes to Claude Code
-    if the API key is all 9s.
-    
+    Create a client that automatically routes to local inference when the API key is all 9s.
+
     Args:
-        api_key: The API key to use. If all 9s, routes to Claude Code.
-    
+        api_key: API key for the selected provider.
+        provider: "claude"/"anthropic" or "codex"/"openai". Overrides the default.
+        default_provider: Which provider to use if none is specified.
+
     Returns:
-        AnthropicRouter instance
+        Router instance for the chosen provider.
     """
+    selected = provider or os.environ.get("AI_ROUTER_DEFAULT", default_provider)
+    selected = selected.lower()
+    if selected in {"codex", "openai"}:
+        return OpenAIRouter(api_key=api_key)
     return AnthropicRouter(api_key=api_key)

--- a/codex_client.py
+++ b/codex_client.py
@@ -1,0 +1,144 @@
+"""
+Codex Client - Interface for routing API calls to Codex CLI
+"""
+import subprocess
+import asyncio
+from typing import Dict, List, Optional
+from datetime import datetime
+from anthropic.types import Message, TextBlock, Usage
+from claude_code_client import ClaudeCodeClient
+
+
+class CodexClient(ClaudeCodeClient):
+    """Client that interfaces with Codex CLI for local inference."""
+
+    def __init__(self):
+        super().__init__()
+        self.claude_command = "codex"
+
+    def _call_claude_cli(self, prompt: str, model: Optional[str] = None) -> str:
+        """Call Codex CLI with the formatted prompt."""
+        cmd = [self.claude_command, "--print"]
+
+        if model:
+            model_map = {
+                "code-davinci-002": "davinci",
+                "code-cushman-001": "cushman",
+            }
+            for full_name, short_name in model_map.items():
+                if full_name in model:
+                    cmd.extend(["--model", short_name])
+                    break
+            else:
+                for name in ["davinci", "cushman"]:
+                    if name in model.lower():
+                        cmd.extend(["--model", name])
+                        break
+
+        try:
+            result = subprocess.run(
+                cmd,
+                input=prompt,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            if result.returncode != 0:
+                error_msg = result.stderr or "Unknown error calling Codex"
+                raise Exception(f"Codex CLI error: {error_msg}")
+            return result.stdout.strip()
+        except subprocess.TimeoutExpired:
+            raise Exception("Codex CLI timed out after 120 seconds")
+        except FileNotFoundError:
+            raise Exception("Codex CLI not found. Please ensure 'codex' is installed and in PATH")
+        except Exception as e:
+            raise Exception(f"Error calling Codex: {str(e)}")
+
+    def create_message(
+        self,
+        messages: List[Dict],
+        model: str,
+        max_tokens: int,
+        system: Optional[str] = None,
+        temperature: Optional[float] = None,
+        stream: bool = False,
+    ) -> Message:
+        message = super().create_message(
+            messages=messages,
+            model=model,
+            max_tokens=max_tokens,
+            system=system,
+            temperature=temperature,
+            stream=stream,
+        )
+        message.id = "msg_codex_" + datetime.now().strftime("%Y%m%d%H%M%S")
+        return message
+
+    async def acreate_message(
+        self,
+        messages: List[Dict],
+        model: str,
+        max_tokens: int,
+        system: Optional[str] = None,
+        temperature: Optional[float] = None,
+        stream: bool = False,
+    ) -> Message:
+        if stream:
+            raise NotImplementedError("Streaming is not yet supported with Codex routing")
+
+        prompt = self._format_messages_for_claude(messages, system)
+
+        cmd = [self.claude_command, "--print"]
+        if model:
+            model_map = {
+                "code-davinci-002": "davinci",
+                "code-cushman-001": "cushman",
+            }
+            for full_name, short_name in model_map.items():
+                if full_name in model:
+                    cmd.extend(["--model", short_name])
+                    break
+            else:
+                for name in ["davinci", "cushman"]:
+                    if name in model.lower():
+                        cmd.extend(["--model", name])
+                        break
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(input=prompt.encode()),
+                timeout=120,
+            )
+            if proc.returncode != 0:
+                error_msg = stderr.decode() if stderr else "Unknown error calling Codex"
+                raise Exception(f"Codex CLI error: {error_msg}")
+            response_text = stdout.decode().strip()
+        except asyncio.TimeoutError:
+            raise Exception("Codex CLI timed out after 120 seconds")
+        except FileNotFoundError:
+            raise Exception("Codex CLI not found. Please ensure 'codex' is installed and in PATH")
+        except Exception as e:
+            raise Exception(f"Error calling Codex: {str(e)}")
+
+        message = Message(
+            id="msg_codex_" + datetime.now().strftime("%Y%m%d%H%M%S"),
+            content=[TextBlock(text=response_text, type="text")],
+            model=model,
+            role="assistant",
+            stop_reason="end_turn",
+            stop_sequence=None,
+            type="message",
+            usage=Usage(
+                input_tokens=len(prompt.split()),
+                output_tokens=len(response_text.split()),
+                cache_creation_input_tokens=None,
+                cache_read_input_tokens=None,
+            ),
+        )
+        return message

--- a/codex_proxy_handler.py
+++ b/codex_proxy_handler.py
@@ -1,0 +1,78 @@
+"""
+Codex Proxy Handler - Handles API requests routed through the proxy for Codex CLI.
+"""
+import asyncio
+from typing import Any, Dict, Optional
+from claude_code_proxy_handler import ClaudeCodeProxyHandler, MAX_PROMPT_LENGTH, logger
+
+CODEX_VALID_MODELS = {
+    "code-davinci-002",
+    "code-cushman-001",
+}
+
+
+class CodexProxyHandler(ClaudeCodeProxyHandler):
+    """Proxy handler that routes requests to the Codex CLI."""
+
+    def __init__(self):
+        super().__init__()
+        self.claude_command = "codex"
+
+    def _validate_model(self, model: str) -> bool:
+        if not model:
+            return True
+        if model in CODEX_VALID_MODELS:
+            return True
+        model_lower = model.lower()
+        return any(k in model_lower for k in ["davinci", "cushman"])
+
+    async def _call_claude_cli_async(self, prompt: str, model: Optional[str] = None) -> str:
+        cmd = [self.claude_command, "--print"]
+        if model:
+            model_map = {
+                "code-davinci-002": "davinci",
+                "code-cushman-001": "cushman",
+            }
+            short_name = None
+            for full_name, mapped in model_map.items():
+                if full_name in model:
+                    short_name = mapped
+                    break
+            if not short_name:
+                model_lower = model.lower()
+                for known in ["davinci", "cushman"]:
+                    if known in model_lower:
+                        short_name = known
+                        break
+            if short_name:
+                cmd.extend(["--model", short_name])
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(input=prompt.encode("utf-8")),
+                timeout=120,
+            )
+            if proc.returncode != 0:
+                error_msg = stderr.decode("utf-8", errors="ignore") if stderr else "Unknown error"
+                logger.error(f"Codex CLI returned non-zero: {proc.returncode}")
+                raise Exception("Codex CLI error")
+            response_text = stdout.decode("utf-8", errors="ignore").strip()
+            if len(response_text) > MAX_PROMPT_LENGTH:
+                logger.warning("Codex response truncated due to length")
+                response_text = response_text[:MAX_PROMPT_LENGTH]
+            return response_text
+        except asyncio.TimeoutError:
+            logger.error("Codex CLI timed out")
+            raise Exception("Codex CLI timed out after 120 seconds")
+        except FileNotFoundError:
+            logger.error("Codex CLI not found")
+            raise Exception("Codex CLI not found. Please ensure 'codex' is installed and in PATH.")
+        except Exception as e:
+            logger.error(f"Error calling Codex: {type(e).__name__}")
+            raise

--- a/openai_router.py
+++ b/openai_router.py
@@ -1,0 +1,179 @@
+"""
+OpenAI API Router that routes to Codex when API key is all 9s
+"""
+import os
+from typing import Any, Dict, List, Optional, Union
+from openai import OpenAI, AsyncOpenAI
+from anthropic.types import Message, MessageParam, TextBlock, Usage
+from anthropic._types import NOT_GIVEN, NotGiven
+from codex_client import CodexClient
+
+
+class OpenAIRouter:
+    """A wrapper around the OpenAI client that routes to Codex CLI when the API key is all 9s."""
+
+    def __init__(self, api_key: Optional[str] = None):
+        self.api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
+        self._is_codex_mode = self._check_codex_mode()
+        if self._is_codex_mode:
+            self.client = CodexClient()
+        else:
+            self.client = OpenAI(api_key=self.api_key)
+
+    def _check_codex_mode(self) -> bool:
+        if not self.api_key:
+            return False
+        key_part = self.api_key.split('-')[-1] if '-' in self.api_key else self.api_key
+        return all(c == '9' for c in key_part)
+
+    @property
+    def messages(self):
+        return MessagesRouter(self)
+
+
+class MessagesRouter:
+    """Routes message creation requests to Codex or OpenAI API."""
+
+    def __init__(self, router: OpenAIRouter):
+        self.router = router
+        self.is_codex = router._is_codex_mode
+
+    def create(
+        self,
+        *,
+        max_tokens: int,
+        messages: List[MessageParam],
+        model: str,
+        metadata: Union[Dict[str, Any], NotGiven] = NOT_GIVEN,
+        stop_sequences: Union[List[str], NotGiven] = NOT_GIVEN,
+        stream: Union[bool, NotGiven] = NOT_GIVEN,
+        system: Union[str, NotGiven] = NOT_GIVEN,
+        temperature: Union[float, NotGiven] = NOT_GIVEN,
+        top_k: Union[int, NotGiven] = NOT_GIVEN,
+        top_p: Union[float, NotGiven] = NOT_GIVEN,
+        **kwargs,
+    ) -> Message:
+        if self.is_codex:
+            return self.router.client.create_message(
+                messages=messages,
+                model=model,
+                max_tokens=max_tokens,
+                system=system if system is not NOT_GIVEN else None,
+                temperature=temperature if temperature is not NOT_GIVEN else None,
+                stream=stream if stream is not NOT_GIVEN else False,
+            )
+        else:
+            openai_messages = []
+            if system is not NOT_GIVEN and system:
+                openai_messages.append({"role": "system", "content": system})
+            openai_messages.extend(messages)
+            response = self.router.client.chat.completions.create(
+                model=model,
+                messages=openai_messages,
+                max_tokens=max_tokens,
+                temperature=temperature if temperature is not NOT_GIVEN else None,
+            )
+            text = response.choices[0].message["content"]
+            usage = response.usage
+            return Message(
+                id=response.id,
+                content=[TextBlock(text=text, type="text")],
+                model=model,
+                role="assistant",
+                stop_reason="end_turn",
+                stop_sequence=None,
+                type="message",
+                usage=Usage(
+                    input_tokens=getattr(usage, "prompt_tokens", 0),
+                    output_tokens=getattr(usage, "completion_tokens", 0),
+                    cache_creation_input_tokens=None,
+                    cache_read_input_tokens=None,
+                ),
+            )
+
+
+class AsyncOpenAIRouter:
+    """Async version of the OpenAIRouter for async operations."""
+
+    def __init__(self, api_key: Optional[str] = None):
+        self.api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
+        self._is_codex_mode = self._check_codex_mode()
+        if self._is_codex_mode:
+            self.client = CodexClient()
+        else:
+            self.client = AsyncOpenAI(api_key=self.api_key)
+
+    def _check_codex_mode(self) -> bool:
+        if not self.api_key:
+            return False
+        key_part = self.api_key.split('-')[-1] if '-' in self.api_key else self.api_key
+        return all(c == '9' for c in key_part)
+
+    @property
+    def messages(self):
+        return AsyncMessagesRouter(self)
+
+
+class AsyncMessagesRouter:
+    def __init__(self, router: AsyncOpenAIRouter):
+        self.router = router
+        self.is_codex = router._is_codex_mode
+
+    async def create(
+        self,
+        *,
+        max_tokens: int,
+        messages: List[MessageParam],
+        model: str,
+        metadata: Union[Dict[str, Any], NotGiven] = NOT_GIVEN,
+        stop_sequences: Union[List[str], NotGiven] = NOT_GIVEN,
+        stream: Union[bool, NotGiven] = NOT_GIVEN,
+        system: Union[str, NotGiven] = NOT_GIVEN,
+        temperature: Union[float, NotGiven] = NOT_GIVEN,
+        top_k: Union[int, NotGiven] = NOT_GIVEN,
+        top_p: Union[float, NotGiven] = NOT_GIVEN,
+        **kwargs,
+    ) -> Message:
+        if self.is_codex:
+            return await self.router.client.acreate_message(
+                messages=messages,
+                model=model,
+                max_tokens=max_tokens,
+                system=system if system is not NOT_GIVEN else None,
+                temperature=temperature if temperature is not NOT_GIVEN else None,
+                stream=stream if stream is not NOT_GIVEN else False,
+            )
+        else:
+            openai_messages = []
+            if system is not NOT_GIVEN and system:
+                openai_messages.append({"role": "system", "content": system})
+            openai_messages.extend(messages)
+            response = await self.router.client.chat.completions.create(
+                model=model,
+                messages=openai_messages,
+                max_tokens=max_tokens,
+                temperature=temperature if temperature is not NOT_GIVEN else None,
+            )
+            text = response.choices[0].message["content"]
+            usage = response.usage
+            return Message(
+                id=response.id,
+                content=[TextBlock(text=text, type="text")],
+                model=model,
+                role="assistant",
+                stop_reason="end_turn",
+                stop_sequence=None,
+                type="message",
+                usage=Usage(
+                    input_tokens=getattr(usage, "prompt_tokens", 0),
+                    output_tokens=getattr(usage, "completion_tokens", 0),
+                    cache_creation_input_tokens=None,
+                    cache_read_input_tokens=None,
+                ),
+            )
+
+
+# Convenience function to create an OpenAI client
+
+def create_openai_client(api_key: Optional[str] = None) -> OpenAIRouter:
+    return OpenAIRouter(api_key=api_key)

--- a/proxy_server.py
+++ b/proxy_server.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-HTTP/HTTPS Proxy Server for Anthropic API interception.
-Routes to Claude Code when API key is all 9s.
-FIXED VERSION with security improvements and bug fixes.
+Universal HTTP/HTTPS Proxy Server for Anthropic and OpenAI API interception.
+Routes to Claude Code or Codex when API keys are all 9s.
+Includes security improvements and bug fixes.
 """
 import asyncio
 import json
@@ -13,6 +13,7 @@ from typing import Optional, Dict, Any
 from mitmproxy import http, options
 from mitmproxy.tools.dump import DumpMaster
 from claude_code_proxy_handler import ClaudeCodeProxyHandler
+from codex_proxy_handler import CodexProxyHandler
 
 # Configure logging
 logging.basicConfig(
@@ -28,18 +29,22 @@ ALLOWED_METHODS = {'GET', 'POST', 'OPTIONS'}
 ALLOWED_PATHS_REGEX = re.compile(r'^/v1/(messages|complete|models)/?.*$')
 
 
-class AnthropicInterceptor:
+class AIInterceptor:
     """
-    Mitmproxy addon that intercepts Anthropic API calls and routes them
-    to Claude Code when the API key is all 9s.
+    Mitmproxy addon that intercepts Anthropic and OpenAI API calls and routes them
+    to local CLIs when the API key is all 9s.
     """
-    
-    def __init__(self):
+
+    def __init__(self, default_backend: str = "claude"):
         self.claude_handler = ClaudeCodeProxyHandler()
+        self.codex_handler = CodexProxyHandler()
+        self.default_backend = default_backend
         self.stats = {
             'total_requests': 0,
             'claude_code_routed': 0,
+            'codex_routed': 0,
             'anthropic_forwarded': 0,
+            'openai_forwarded': 0,
             'errors': 0,
             'blocked_requests': 0
         }
@@ -57,9 +62,12 @@ class AnthropicInterceptor:
         return len(key_part) > 0 and len(key_part) < 100 and all(c == '9' for c in key_part)
     
     def _is_anthropic_request(self, flow: http.HTTPFlow) -> bool:
-        """Check if this is a request to Anthropic API."""
         host = flow.request.pretty_host.lower()
         return host in ['api.anthropic.com', 'anthropic.com']
+
+    def _is_openai_request(self, flow: http.HTTPFlow) -> bool:
+        host = flow.request.pretty_host.lower()
+        return host in ['api.openai.com', 'openai.com']
     
     def _validate_request(self, flow: http.HTTPFlow) -> Optional[Dict[str, Any]]:
         """Validate and sanitize the request."""
@@ -94,9 +102,11 @@ class AnthropicInterceptor:
     
     async def request(self, flow: http.HTTPFlow) -> None:
         """Handle intercepted HTTP requests."""
-        if not self._is_anthropic_request(flow):
+        is_anthropic = self._is_anthropic_request(flow)
+        is_openai = self._is_openai_request(flow)
+        if not (is_anthropic or is_openai):
             return
-        
+
         self.stats['total_requests'] += 1
         
         # Validate request
@@ -122,15 +132,24 @@ class AnthropicInterceptor:
             if auth_header and len(auth_header) < 500 and auth_header.startswith('Bearer '):
                 api_key = auth_header[7:]
         
-        # Check if we should route to Claude Code
+        # Determine routing based on API key and host
         if self._is_all_nines(api_key):
-            logger.info(f"🔀 Routing to Claude Code: {flow.request.method} {flow.request.path}")
-            self.stats['claude_code_routed'] += 1
-            await self._handle_claude_code_request(flow)
+            if is_openai or (not is_anthropic and self.default_backend == 'codex'):
+                logger.info(f"🔀 Routing to Codex: {flow.request.method} {flow.request.path}")
+                self.stats['codex_routed'] += 1
+                await self._handle_codex_request(flow)
+            else:
+                logger.info(f"🔀 Routing to Claude Code: {flow.request.method} {flow.request.path}")
+                self.stats['claude_code_routed'] += 1
+                await self._handle_claude_code_request(flow)
         else:
-            logger.info(f"➡️  Forwarding to Anthropic API: {flow.request.method} {flow.request.path}")
-            self.stats['anthropic_forwarded'] += 1
-            # Let the request pass through to the real Anthropic API
+            if is_openai:
+                logger.info(f"➡️  Forwarding to OpenAI API: {flow.request.method} {flow.request.path}")
+                self.stats['openai_forwarded'] += 1
+            else:
+                logger.info(f"➡️  Forwarding to Anthropic API: {flow.request.method} {flow.request.path}")
+                self.stats['anthropic_forwarded'] += 1
+            # Let the request pass through upstream
     
     async def _handle_claude_code_request(self, flow: http.HTTPFlow) -> None:
         """Route the request to Claude Code and return the response."""
@@ -242,10 +261,110 @@ class AnthropicInterceptor:
                 json.dumps({"error": {"type": "internal_error", "message": "An internal error occurred"}}),
                 {"Content-Type": "application/json"}
             )
+
+
+    async def _handle_codex_request(self, flow: http.HTTPFlow) -> None:
+        """Route the request to Codex and return the response."""
+        try:
+            request_data = {}
+            if flow.request.content:
+                if len(flow.request.content) > MAX_REQUEST_SIZE:
+                    flow.response = http.Response.make(
+                        413,
+                        json.dumps({"error": {"type": "request_too_large", "message": "Request body too large"}}),
+                        {"Content-Type": "application/json"},
+                    )
+                    return
+                try:
+                    content_str = flow.request.content.decode('utf-8', errors='ignore')
+                    request_data = json.loads(content_str)
+                except (json.JSONDecodeError, UnicodeDecodeError) as e:
+                    logger.error(f"Failed to parse request: {e}")
+                    flow.response = http.Response.make(
+                        400,
+                        json.dumps({"error": {"type": "invalid_request", "message": "Invalid JSON in request body"}}),
+                        {"Content-Type": "application/json"},
+                    )
+                    return
     
+            if not isinstance(request_data, dict):
+                flow.response = http.Response.make(
+                    400,
+                    json.dumps({"error": {"type": "invalid_request", "message": "Request body must be a JSON object"}}),
+                    {"Content-Type": "application/json"},
+                )
+                return
+    
+            status_code = 404
+            response_data = {}
+            path = flow.request.path.lower()
+            if '/v1/messages' in path:
+                response_data = await self.codex_handler.handle_messages_request(
+                    request_data,
+                    flow.request.method,
+                )
+            elif '/v1/complete' in path:
+                response_data = await self.codex_handler.handle_complete_request(
+                    request_data,
+                    flow.request.method,
+                )
+            elif '/v1/models' in path and flow.request.method == 'GET':
+                response_data = {
+                    "data": [
+                        {"id": "code-davinci-002", "object": "model"},
+                        {"id": "code-cushman-001", "object": "model"},
+                    ]
+                }
+            else:
+                response_data = {
+                    "error": {
+                        "type": "not_found_error",
+                        "message": f"Endpoint {flow.request.path} not supported in Codex mode",
+                    }
+                }
+    
+            if 'error' in response_data:
+                error_type = response_data.get('error', {}).get('type', '')
+                if 'not_found' in error_type:
+                    status_code = 404
+                elif 'invalid' in error_type or 'request' in error_type:
+                    status_code = 400
+                elif 'unauthorized' in error_type:
+                    status_code = 401
+                else:
+                    status_code = 500
+            else:
+                status_code = 200
+    
+            response_json = json.dumps(response_data)
+            flow.response = http.Response.make(
+                status_code,
+                response_json,
+                {
+                    "Content-Type": "application/json",
+                    "Content-Length": str(len(response_json)),
+                },
+            )
+    
+        except asyncio.TimeoutError:
+            logger.error("Codex request timed out")
+            self.stats['errors'] += 1
+            flow.response = http.Response.make(
+                504,
+                json.dumps({"error": {"type": "timeout_error", "message": "Request timed out"}}),
+                {"Content-Type": "application/json"},
+            )
+        except Exception as e:
+            logger.error(f"Error handling Codex request: {e}", exc_info=True)
+            self.stats['errors'] += 1
+            flow.response = http.Response.make(
+                500,
+                json.dumps({"error": {"type": "internal_error", "message": "An internal error occurred"}}),
+                {"Content-Type": "application/json"},
+            )
     def response(self, flow: http.HTTPFlow) -> None:
         """Handle responses (for logging/stats)."""
-        if self._is_anthropic_request(flow) and flow.response:
+        if (self._is_anthropic_request(flow) or self._is_openai_request(flow)) and flow.response:
             status = flow.response.status_code
             if status >= 400:
                 self.stats['errors'] += 1
@@ -259,33 +378,35 @@ class AnthropicInterceptor:
         logger.info("\n📊 Proxy Statistics:")
         logger.info(f"  Total requests: {self.stats['total_requests']}")
         logger.info(f"  Routed to Claude Code: {self.stats['claude_code_routed']}")
+        logger.info(f"  Routed to Codex: {self.stats['codex_routed']}")
         logger.info(f"  Forwarded to Anthropic: {self.stats['anthropic_forwarded']}")
+        logger.info(f"  Forwarded to OpenAI: {self.stats['openai_forwarded']}")
         logger.info(f"  Blocked requests: {self.stats['blocked_requests']}")
         logger.info(f"  Errors: {self.stats['errors']}")
 
 
-async def start_proxy(host: str = "127.0.0.1", port: int = 8080):
+async def start_proxy(host: str = "127.0.0.1", port: int = 8080, default_backend: str = "claude"):
     """Start the mitmproxy server."""
     # Validate host and port
     if not re.match(r'^[\d.]+$|^localhost$|^[\da-fA-F:]+$', host):
         raise ValueError(f"Invalid host: {host}")
     if not 1 <= port <= 65535:
         raise ValueError(f"Invalid port: {port}")
-    
+
     # Configure mitmproxy options
     opts = options.Options(
         listen_host=host,
         listen_port=port,
-        ssl_insecure=True,  # Accept any cert for upstream
+        ssl_insecure=True,
     )
-    
+
     # Create master with our interceptor
     master = DumpMaster(opts)
-    master.addons.add(AnthropicInterceptor())
-    
+    master.addons.add(AIInterceptor(default_backend=default_backend))
+
     logger.info(f"""
 ╔══════════════════════════════════════════════════════════╗
-║          Anthropic API Proxy Server Started!              ║
+║          AI API Proxy Server Started!                     ║
 ╠══════════════════════════════════════════════════════════╣
 ║  Proxy URL: http://{host}:{port:<5}                          ║
 ║                                                            ║
@@ -293,11 +414,11 @@ async def start_proxy(host: str = "127.0.0.1", port: int = 8080):
 ║  • HTTP_PROXY=http://{host}:{port:<5}                        ║
 ║  • HTTPS_PROXY=http://{host}:{port:<5}                       ║
 ║                                                            ║
-║  API keys with all 9s will route to Claude Code           ║
-║  Other API keys will forward to Anthropic API             ║
+║  API keys with all 9s will route to local CLI             ║
+║  Other API keys will forward upstream                     ║
 ╚══════════════════════════════════════════════════════════╝
     """)
-    
+
     try:
         await master.run()
     except KeyboardInterrupt:
@@ -308,19 +429,21 @@ async def start_proxy(host: str = "127.0.0.1", port: int = 8080):
 def main():
     """Main entry point."""
     import argparse
-    
-    parser = argparse.ArgumentParser(description='Anthropic API Proxy Server')
+
+    parser = argparse.ArgumentParser(description='Universal AI Proxy Server')
     parser.add_argument('--host', default='127.0.0.1', help='Host to bind to (default: 127.0.0.1)')
     parser.add_argument('--port', type=int, default=8080, help='Port to listen on (default: 8080)')
     parser.add_argument('--verbose', action='store_true', help='Enable verbose logging')
-    
+    parser.add_argument('--default-backend', choices=['claude', 'codex'], default='claude',
+                        help='Default local backend when API key is all 9s')
+
     args = parser.parse_args()
-    
+
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
-    
+
     try:
-        asyncio.run(start_proxy(args.host, args.port))
+        asyncio.run(start_proxy(args.host, args.port, args.default_backend))
     except KeyboardInterrupt:
         logger.info("\nProxy server stopped.")
         sys.exit(0)
@@ -330,7 +453,7 @@ def main():
     except Exception as e:
         logger.error(f"Unexpected error: {e}", exc_info=True)
         sys.exit(1)
-
-
+    
+    
 if __name__ == '__main__':
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 anthropic>=0.18.0
+openai>=1.0.0
 mitmproxy>=10.0.0
 cryptography>=41.0.0

--- a/test_codex_router.py
+++ b/test_codex_router.py
@@ -1,0 +1,8 @@
+"""Simple tests for Codex routing"""
+from anthropic_router import create_client
+from codex_client import CodexClient
+
+
+def test_codex_detection():
+    client = create_client(provider="codex", api_key="999999999")
+    assert isinstance(client.client, CodexClient)


### PR DESCRIPTION
## Summary
- extend router and proxy to support Codex and OpenAI requests
- allow selecting default backend and switching between Claude Code and Codex
- document cross-platform usage for both CLIs

## Testing
- `python -m py_compile codex_client.py codex_proxy_handler.py openai_router.py anthropic_router.py`
- `python -m py_compile proxy_server.py`
- `pip install -r requirements.txt`
- `pip install requests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c39ca0fd7483218fef3eee5b4c2e1b