### PR TITLE
Add cross-platform start script and OS-specific usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A drop-in replacement for the Anthropic Python client that handles routing inter
 
 ```bash
 pip install -r requirements.txt
+# On Windows you can also use: py -m pip install -r requirements.txt
 ```
 
 Make sure you have the relevant CLI installed and available in your PATH:
@@ -39,15 +40,28 @@ codex --version    # for Codex
 1. **Setup and start the proxy:**
 ```bash
 python setup_proxy.py  # One-time setup
+# macOS / Linux
 ./start_proxy.sh       # Start proxy server
+# Windows
+python start_proxy.py
 ```
 
 2. **Configure your environment (examples):**
+
+macOS/Linux (bash/zsh):
 ```bash
 export HTTP_PROXY=http://localhost:8080
 export HTTPS_PROXY=http://localhost:8080
 export ANTHROPIC_API_KEY=999999999999   # All 9s for Claude Code
 export OPENAI_API_KEY=999999999999      # All 9s for Codex
+```
+
+Windows (PowerShell):
+```powershell
+$env:HTTP_PROXY="http://localhost:8080"
+$env:HTTPS_PROXY="http://localhost:8080"
+$env:ANTHROPIC_API_KEY="999999999999"   # All 9s for Claude Code
+$env:OPENAI_API_KEY="999999999999"      # All 9s for Codex
 ```
 
 3. **Use from ANY language/tool:**
@@ -130,6 +144,7 @@ The following API key formats will trigger Claude Code routing:
 - `claude_code_proxy_handler.py` - Proxy request handler for Claude Code
 - `setup_proxy.py` - One-time setup script for proxy
 - `start_proxy.sh` - Convenient proxy launcher script
+- `start_proxy.py` - Cross-platform proxy launcher script
 - `test_universal.py` - Tests for multiple languages/tools
 
 ### Python Library

--- a/start_proxy.py
+++ b/start_proxy.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Cross-platform launcher for Anthropic API proxy server."""
+import argparse
+import shutil
+import subprocess
+import sys
+
+
+def command_exists(cmd: str) -> bool:
+    """Check if a command exists on PATH."""
+    return shutil.which(cmd) is not None
+
+
+def ensure_dependencies() -> None:
+    """Verify required dependencies are available, installing if needed."""
+    if not command_exists("claude"):
+        print("⚠️  Warning: Claude Code CLI not found; local routing will fail.")
+
+    try:
+        import mitmproxy  # noqa: F401
+    except Exception:
+        print("Installing Python dependencies...")
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"])
+
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Anthropic API Proxy Server Launcher")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", default="8080")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging")
+    args = parser.parse_args()
+
+    ensure_dependencies()
+
+    cmd = [sys.executable, "proxy_server.py", "--host", args.host, "--port", args.port]
+    if args.verbose:
+        cmd.append("--verbose")
+    subprocess.call(cmd)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `start_proxy.py` python launcher so proxy works on Windows, macOS, and Linux
- document Windows and Unix instructions for installing dependencies and setting environment variables
- list new launcher script in project files

## Testing
- `python -m pip install -r requirements.txt`
- `python test_router.py` *(fails: Claude Code CLI not found)*
- `python test_openai_router.py`
- `python test_codex_router.py`
- `python test_universal.py` *(skipped: integration tests requiring network/proxy)*
- `python test_simple.py` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c49789d6b0832180e456dc6cbeab34