### PR TITLE
Allow OpenAI endpoints and add tests

### DIFF
--- a/proxy_server.py
+++ b/proxy_server.py
@@ -26,7 +26,16 @@ logger = logging.getLogger(__name__)
 MAX_REQUEST_SIZE = 10 * 1024 * 1024  # 10MB max request size
 MAX_PROMPT_LENGTH = 100000  # Max characters in prompt
 ALLOWED_METHODS = {'GET', 'POST', 'OPTIONS'}
-ALLOWED_PATHS_REGEX = re.compile(r'^/v1/(messages|complete|models)/?.*$')
+# Allow only specific API endpoints while preventing traversal or unexpected paths
+# - /v1/messages
+# - /v1/complete
+# - /v1/chat/completions
+# - /v1/completions
+# - /v1/models or /v1/models/{model}
+# Optional query strings are permitted, but additional path segments are rejected
+ALLOWED_PATHS_REGEX = re.compile(
+    r'^/v1/(?:messages|complete|chat/completions|completions|models(?:/[A-Za-z0-9_.-]+)?)(?:\?.*)?$'
+)
 
 
 class AIInterceptor:

--- a/test_proxy_server_paths.py
+++ b/test_proxy_server_paths.py
@@ -1,0 +1,18 @@
+import proxy_server
+
+class DummyRequest:
+    def __init__(self, path, method="POST", content=b""):
+        self.path = path
+        self.method = method
+        self.content = content
+
+class DummyFlow:
+    def __init__(self, path, method="POST", content=b""):
+        self.request = DummyRequest(path, method, content)
+
+
+def test_openai_endpoints_allowed():
+    interceptor = proxy_server.AIInterceptor()
+    for path in ["/v1/chat/completions", "/v1/completions"]:
+        flow = DummyFlow(path)
+        assert interceptor._validate_request(flow) is None, f"{path} should be allowed"


### PR DESCRIPTION
## Summary
- permit OpenAI chat/completion paths in allowed request regex
- add unit test ensuring OpenAI chat/completion paths are accepted

## Testing
- `pytest test_proxy_server_paths.py`
- `pytest` *(fails: test_codex_router.py::test_openai_message_list_content_conversion, test_codex_router.py::test_openai_message_list_content_conversion_async, test_openai_router.py::test_stop_sequences_passed_to_openai, test_openai_router.py::test_async_stop_sequences_passed_to_openai, tests/test_timeout_cleanup.py::test_client_process_killed_on_timeout[ClaudeCodeClient], tests/test_timeout_cleanup.py::test_client_process_killed_on_timeout[CodexClient], tests/test_timeout_cleanup.py::test_handler_process_killed_on_timeout[ClaudeCodeProxyHandler], tests/test_timeout_cleanup.py::test_handler_process_killed_on_timeout[CodexProxyHandler])`

------
https://chatgpt.com/codex/tasks/task_e_68c4c682df508321933f6a437a91c2e1