### PR TITLE
Add missing requests import for universal proxy tests

### DIFF
--- a/test_universal.py
+++ b/test_universal.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import time
 import json
+import requests
 from anthropic import Anthropic
 import pytest
 


### PR DESCRIPTION
## Summary
- import the `requests` library in `test_universal.py` to avoid NameError when running direct HTTP request test

## Testing
- `pytest test_universal.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4c93b67148321bcc98b49ef274d5d