### PR TITLE
refactor api key mode check

### DIFF
--- a/anthropic_router.py
+++ b/anthropic_router.py
@@ -8,6 +8,7 @@ from anthropic.types import Message, MessageParam
 from anthropic._types import NOT_GIVEN, NotGiven
 from claude_code_client import ClaudeCodeClient
 from openai_router import OpenAIRouter
+from utils import is_all_nines_api_key
 
 
 class AnthropicRouter:
@@ -18,20 +19,12 @@ class AnthropicRouter:
     
     def __init__(self, api_key: Optional[str] = None):
         self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
-        self._is_claude_code_mode = self._check_claude_code_mode()
+        self._is_claude_code_mode = is_all_nines_api_key(self.api_key)
         
         if self._is_claude_code_mode:
             self.client = ClaudeCodeClient()
         else:
             self.client = Anthropic(api_key=self.api_key)
-    
-    def _check_claude_code_mode(self) -> bool:
-        """Check if the API key is all 9s to enable Claude Code routing."""
-        if not self.api_key:
-            return False
-        # Remove any common prefixes like "sk-ant-" if present
-        key_part = self.api_key.split('-')[-1] if '-' in self.api_key else self.api_key
-        return all(c == '9' for c in key_part)
     
     @property
     def messages(self):
@@ -98,19 +91,12 @@ class AsyncAnthropicRouter:
     
     def __init__(self, api_key: Optional[str] = None):
         self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
-        self._is_claude_code_mode = self._check_claude_code_mode()
+        self._is_claude_code_mode = is_all_nines_api_key(self.api_key)
         
         if self._is_claude_code_mode:
             self.client = ClaudeCodeClient()
         else:
             self.client = AsyncAnthropic(api_key=self.api_key)
-    
-    def _check_claude_code_mode(self) -> bool:
-        """Check if the API key is all 9s to enable Claude Code routing."""
-        if not self.api_key:
-            return False
-        key_part = self.api_key.split('-')[-1] if '-' in self.api_key else self.api_key
-        return all(c == '9' for c in key_part)
     
     @property
     def messages(self):

--- a/openai_router.py
+++ b/openai_router.py
@@ -7,6 +7,7 @@ from openai import OpenAI, AsyncOpenAI
 from anthropic.types import Message, MessageParam, TextBlock, Usage
 from anthropic._types import NOT_GIVEN, NotGiven
 from codex_client import CodexClient
+from utils import is_all_nines_api_key
 
 
 class OpenAIRouter:
@@ -14,17 +15,11 @@ class OpenAIRouter:
 
     def __init__(self, api_key: Optional[str] = None):
         self.api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
-        self._is_codex_mode = self._check_codex_mode()
+        self._is_codex_mode = is_all_nines_api_key(self.api_key)
         if self._is_codex_mode:
             self.client = CodexClient()
         else:
             self.client = OpenAI(api_key=self.api_key)
-
-    def _check_codex_mode(self) -> bool:
-        if not self.api_key:
-            return False
-        key_part = self.api_key.split('-')[-1] if '-' in self.api_key else self.api_key
-        return all(c == '9' for c in key_part)
 
     @property
     def messages(self):
@@ -105,17 +100,11 @@ class AsyncOpenAIRouter:
 
     def __init__(self, api_key: Optional[str] = None):
         self.api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
-        self._is_codex_mode = self._check_codex_mode()
+        self._is_codex_mode = is_all_nines_api_key(self.api_key)
         if self._is_codex_mode:
             self.client = CodexClient()
         else:
             self.client = AsyncOpenAI(api_key=self.api_key)
-
-    def _check_codex_mode(self) -> bool:
-        if not self.api_key:
-            return False
-        key_part = self.api_key.split('-')[-1] if '-' in self.api_key else self.api_key
-        return all(c == '9' for c in key_part)
 
     @property
     def messages(self):

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,0 +1,12 @@
+import utils
+
+
+def test_is_all_nines_api_key_true_cases():
+    assert utils.is_all_nines_api_key("999999")
+    assert utils.is_all_nines_api_key("sk-ant-999")
+
+
+def test_is_all_nines_api_key_false_cases():
+    assert not utils.is_all_nines_api_key("123456")
+    assert not utils.is_all_nines_api_key("sk-ant-123")
+    assert not utils.is_all_nines_api_key(None)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,9 @@
+from typing import Optional
+
+
+def is_all_nines_api_key(api_key: Optional[str]) -> bool:
+    """Return True if the API key (after removing any prefix) is all 9s."""
+    if not api_key:
+        return False
+    key_part = api_key.split('-')[-1] if '-' in api_key else api_key
+    return all(c == '9' for c in key_part)


### PR DESCRIPTION
## Summary
- extract repeated all-nines API key detection into `utils.is_all_nines_api_key`
- update Anthropic and OpenAI routers to use shared helper
- add unit tests for API key helper

## Testing
- `pytest test_utils.py -q`
- `pytest -q` *(fails: test_codex_router.py::test_openai_message_list_content_conversion, test_codex_router.py::test_openai_message_list_content_conversion_async, test_openai_router.py::test_stop_sequences_passed_to_openai, test_openai_router.py::test_async_stop_sequences_passed_to_openai)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ca084ecc8321b8d4a894a52d3f01