### PR TITLE
refactor subprocess timeout handling

### DIFF
--- a/claude_code_client.py
+++ b/claude_code_client.py
@@ -1,11 +1,8 @@
-"""
-Claude Code Client - Interface for routing API calls to Claude Code CLI
-"""
-import subprocess
-import asyncio
+"""Claude Code Client - Interface for routing API calls to Claude Code CLI"""
 from typing import Dict, List, Optional
 from datetime import datetime
 from anthropic.types import Message, TextBlock, Usage
+from utils import run_subprocess, run_subprocess_async
 
 
 class ClaudeCodeClient:
@@ -86,29 +83,7 @@ class ClaudeCodeClient:
                     model_short = next((name for name in ["opus", "sonnet", "haiku"] if name in model.lower()), "sonnet")
                     cmd.extend(["--model", model_short])
         
-        try:
-            # Run Claude Code CLI, passing the prompt via stdin to avoid
-            # command-line length limits
-            result = subprocess.run(
-                cmd,
-                input=prompt,
-                capture_output=True,
-                text=True,
-                timeout=120  # 2 minute timeout
-            )
-            
-            if result.returncode != 0:
-                error_msg = result.stderr or "Unknown error calling Claude Code"
-                raise Exception(f"Claude Code CLI error: {error_msg}")
-            
-            return result.stdout.strip()
-            
-        except subprocess.TimeoutExpired:
-            raise Exception("Claude Code CLI timed out after 120 seconds")
-        except FileNotFoundError:
-            raise Exception("Claude Code CLI not found. Please ensure 'claude' is installed and in PATH")
-        except Exception as e:
-            raise Exception(f"Error calling Claude Code: {str(e)}")
+        return run_subprocess(cmd, prompt, "Claude Code")
     
     def create_message(
         self,
@@ -171,7 +146,7 @@ class ClaudeCodeClient:
         
         # Call Claude Code CLI asynchronously
         cmd = [self.claude_command, "--print"]
-        
+
         # Add model selection if specified
         if model:
             model_map = {
@@ -179,47 +154,22 @@ class ClaudeCodeClient:
                 "claude-3-sonnet-20240229": "sonnet",
                 "claude-3-haiku-20240307": "haiku",
                 "claude-3-5-sonnet-20241022": "sonnet",
-                "claude-3-5-haiku-20241022": "haiku"
+                "claude-3-5-haiku-20241022": "haiku",
             }
-            
+
             for full_name, short_name in model_map.items():
                 if full_name in model:
                     cmd.extend(["--model", short_name])
                     break
             else:
                 if any(name in model.lower() for name in ["opus", "sonnet", "haiku"]):
-                    model_short = next((name for name in ["opus", "sonnet", "haiku"] if name in model.lower()), "sonnet")
+                    model_short = next(
+                        (name for name in ["opus", "sonnet", "haiku"] if name in model.lower()),
+                        "sonnet",
+                    )
                     cmd.extend(["--model", model_short])
-        
-        try:
-            # Run Claude Code CLI asynchronously, sending the prompt via stdin
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
-            )
 
-            try:
-                stdout, stderr = await asyncio.wait_for(
-                    proc.communicate(input=prompt.encode()),
-                    timeout=120
-                )
-            except asyncio.TimeoutError:
-                proc.kill()
-                await proc.communicate()
-                raise Exception("Claude Code CLI timed out after 120 seconds")
-
-            if proc.returncode != 0:
-                error_msg = stderr.decode() if stderr else "Unknown error calling Claude Code"
-                raise Exception(f"Claude Code CLI error: {error_msg}")
-
-            response_text = stdout.decode().strip()
-
-        except FileNotFoundError:
-            raise Exception("Claude Code CLI not found. Please ensure 'claude' is installed and in PATH")
-        except Exception as e:
-            raise Exception(f"Error calling Claude Code: {str(e)}")
+        response_text = await run_subprocess_async(cmd, prompt, "Claude Code")
         
         # Create a Message object that matches Anthropic's format
         message = Message(

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,6 @@
-from typing import Optional
+import asyncio
+import subprocess
+from typing import List, Optional
 
 
 def is_all_nines_api_key(api_key: Optional[str]) -> bool:
@@ -7,3 +9,65 @@ def is_all_nines_api_key(api_key: Optional[str]) -> bool:
         return False
     key_part = api_key.split('-')[-1] if '-' in api_key else api_key
     return all(c == '9' for c in key_part)
+
+
+def run_subprocess(cmd: List[str], input_text: str, name: str, *, timeout: int = 120,
+                   include_stderr: bool = True) -> str:
+    """Run a subprocess command with timeout handling."""
+    try:
+        result = subprocess.run(
+            cmd,
+            input=input_text,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        raise Exception(f"{name} CLI timed out after {timeout} seconds")
+    except FileNotFoundError:
+        raise Exception(
+            f"{name} CLI not found. Please ensure '{cmd[0]}' is installed and in PATH"
+        )
+    except Exception as e:
+        raise Exception(f"Error calling {name}: {str(e)}")
+
+    if result.returncode != 0:
+        error_msg = result.stderr or "Unknown error"
+        if include_stderr:
+            raise Exception(f"{name} CLI error: {error_msg}")
+        raise Exception(f"{name} CLI error")
+
+    return result.stdout.strip()
+
+
+async def run_subprocess_async(cmd: List[str], input_text: str, name: str, *, timeout: int = 120,
+                                include_stderr: bool = True) -> str:
+    """Run a subprocess command asynchronously with timeout handling."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        raise Exception(
+            f"{name} CLI not found. Please ensure '{cmd[0]}' is installed and in PATH"
+        )
+
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(input=input_text.encode()), timeout=timeout
+        )
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.communicate()
+        raise Exception(f"{name} CLI timed out after {timeout} seconds")
+
+    if proc.returncode != 0:
+        error_msg = stderr.decode() if stderr else "Unknown error"
+        if include_stderr:
+            raise Exception(f"{name} CLI error: {error_msg}")
+        raise Exception(f"{name} CLI error")
+
+    return stdout.decode().strip()


### PR DESCRIPTION
## Summary
- extract shared subprocess helpers for sync and async execution
- refactor clients and proxy handlers to use common helpers

## Testing
- `pytest tests/test_timeout_cleanup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4cc0a0108832182da6bb833f7e694