### PR TITLE
Handle codex completion endpoints

### DIFF
--- a/test_codex_router.py
+++ b/test_codex_router.py
@@ -20,7 +20,7 @@ def test_openai_message_list_content_conversion(monkeypatch):
             self.choices = [type("Choice", (), {"message": type("Msg", (), {"content": "ok"})()})]
             self.usage = type("Usage", (), {"prompt_tokens": 0, "completion_tokens": 0})()
 
-    def fake_create(*, model, messages, max_tokens, temperature=None):
+    def fake_create(*, model, messages, max_tokens, temperature=None, stop=None):
         captured["messages"] = messages
         return DummyResp()
 
@@ -44,7 +44,7 @@ async def test_openai_message_list_content_conversion_async(monkeypatch):
             self.choices = [type("Choice", (), {"message": type("Msg", (), {"content": "ok"})()})]
             self.usage = type("Usage", (), {"prompt_tokens": 0, "completion_tokens": 0})()
 
-    async def fake_create(*, model, messages, max_tokens, temperature=None):
+    async def fake_create(*, model, messages, max_tokens, temperature=None, stop=None):
         captured["messages"] = messages
         return DummyResp()
 

--- a/test_openai_router.py
+++ b/test_openai_router.py
@@ -11,7 +11,7 @@ def test_stop_sequences_passed_to_openai(monkeypatch):
 
         class Choice:
             def __init__(self):
-                self.message = {"content": "hello"}
+                self.message = type("Msg", (), {"content": "hello"})()
 
         choices = [Choice()]
 
@@ -53,7 +53,7 @@ def test_async_stop_sequences_passed_to_openai(monkeypatch):
 
         class Choice:
             def __init__(self):
-                self.message = {"content": "hello"}
+                self.message = type("Msg", (), {"content": "hello"})()
 
         choices = [Choice()]
 

--- a/test_proxy_server_codex.py
+++ b/test_proxy_server_codex.py
@@ -1,0 +1,76 @@
+import json
+import pytest
+import proxy_server
+
+
+class DummyRequest:
+    def __init__(self, path, method="POST", content=b"{}"):
+        self.path = path
+        self.method = method
+        self.content = content
+
+
+class DummyFlow:
+    def __init__(self, path, method="POST", content=b"{}"):
+        self.request = DummyRequest(path, method, content)
+        self.response = None
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_success(monkeypatch):
+    interceptor = proxy_server.AIInterceptor()
+
+    async def mock_messages(data, method):
+        return {"id": "1"}
+
+    monkeypatch.setattr(interceptor.codex_handler, "handle_messages_request", mock_messages)
+
+    body = json.dumps({"messages": [{"role": "user", "content": "hi"}]})
+    flow = DummyFlow("/v1/chat/completions", content=body.encode())
+    await interceptor._handle_codex_request(flow)
+    assert flow.response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_not_found(monkeypatch):
+    interceptor = proxy_server.AIInterceptor()
+
+    async def mock_messages(data, method):
+        return {"error": {"type": "not_found_error", "message": "missing"}}
+
+    monkeypatch.setattr(interceptor.codex_handler, "handle_messages_request", mock_messages)
+
+    body = json.dumps({"messages": []})
+    flow = DummyFlow("/v1/chat/completions", content=body.encode())
+    await interceptor._handle_codex_request(flow)
+    assert flow.response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_completions_success(monkeypatch):
+    interceptor = proxy_server.AIInterceptor()
+
+    async def mock_complete(data, method):
+        return {"completion": "ok"}
+
+    monkeypatch.setattr(interceptor.codex_handler, "handle_complete_request", mock_complete)
+
+    body = json.dumps({"prompt": "hi"})
+    flow = DummyFlow("/v1/completions", content=body.encode())
+    await interceptor._handle_codex_request(flow)
+    assert flow.response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_completions_invalid(monkeypatch):
+    interceptor = proxy_server.AIInterceptor()
+
+    async def mock_complete(data, method):
+        return {"error": {"type": "invalid_request_error", "message": "bad"}}
+
+    monkeypatch.setattr(interceptor.codex_handler, "handle_complete_request", mock_complete)
+
+    body = json.dumps({"prompt": "hi"})
+    flow = DummyFlow("/v1/completions", content=body.encode())
+    await interceptor._handle_codex_request(flow)
+    assert flow.response.status_code == 400


### PR DESCRIPTION
## Summary
- route /v1/chat/completions and /v1/completions to Codex handlers in AIInterceptor
- determine Codex response status code from handler output
- add unit tests for success and error scenarios of new Codex endpoints

## Testing
- `pip show requests pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4e67cfdec83218a2eef02c0f03cff