### PR TITLE
Normalize OpenAI content handling

### DIFF
--- a/test_openai_router.py
+++ b/test_openai_router.py
@@ -193,3 +193,123 @@ def test_async_stream_passed_to_openai(monkeypatch):
     msg = asyncio.run(run())
     assert captured["stream"] is True
     assert msg.content[0].text == "hello"
+
+
+def test_dict_content_normalization(monkeypatch):
+    captured = {}
+
+    class MockResponse:
+        id = "resp"
+
+        class Choice:
+            def __init__(self):
+                self.message = type("Msg", (), {"content": "ok"})()
+
+        choices = [Choice()]
+
+        class Usage:
+            prompt_tokens = 0
+            completion_tokens = 0
+
+        usage = Usage()
+
+    class MockChatCompletions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return MockResponse()
+
+    class MockChat:
+        def __init__(self):
+            self.completions = MockChatCompletions()
+
+    class MockClient:
+        def __init__(self, *args, **kwargs):
+            self.chat = MockChat()
+
+    monkeypatch.setattr(openai_router, "OpenAI", lambda api_key=None: MockClient())
+    router = OpenAIRouter(api_key="real-key")
+    router.messages.create(
+        model="gpt-4",
+        max_tokens=5,
+        messages=[
+            {"role": "user", "content": {"type": "text", "text": "hello"}},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "foo"},
+                    {"type": "image", "url": "http://"},
+                    {"type": "text", "text": "bar"},
+                ],
+            },
+        ],
+    )
+    assert captured["messages"][0]["content"] == "hello"
+    assert (
+        captured["messages"][1]["content"]
+        == "foo [image content] bar"
+    )
+    for msg in captured["messages"]:
+        assert isinstance(msg["content"], str)
+
+
+def test_async_dict_content_normalization(monkeypatch):
+    captured = {}
+
+    class MockResponse:
+        id = "resp"
+
+        class Choice:
+            def __init__(self):
+                self.message = type("Msg", (), {"content": "ok"})()
+
+        choices = [Choice()]
+
+        class Usage:
+            prompt_tokens = 0
+            completion_tokens = 0
+
+        usage = Usage()
+
+    class MockChatCompletions:
+        async def create(self, **kwargs):
+            captured.update(kwargs)
+            return MockResponse()
+
+    class MockChat:
+        def __init__(self):
+            self.completions = MockChatCompletions()
+
+    class MockClient:
+        def __init__(self, *args, **kwargs):
+            self.chat = MockChat()
+
+    monkeypatch.setattr(openai_router, "AsyncOpenAI", lambda api_key=None: MockClient())
+    router = AsyncOpenAIRouter(api_key="real-key")
+
+    async def run():
+        await router.messages.create(
+            model="gpt-4",
+            max_tokens=5,
+            messages=[
+                {"role": "user", "content": {"type": "text", "text": "hello"}},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "foo"},
+                        {"type": "image", "url": "http://"},
+                        {"type": "text", "text": "bar"},
+                    ],
+                },
+            ],
+        )
+
+    import asyncio
+
+    asyncio.run(run())
+    assert captured["messages"][0]["content"] == "hello"
+    assert (
+        captured["messages"][1]["content"]
+        == "foo [image content] bar"
+    )
+    for msg in captured["messages"]:
+        assert isinstance(msg["content"], str)


### PR DESCRIPTION
## Summary
- Normalize heterogeneous message content to plain strings for OpenAI requests
- Join list-based text parts with spaces and substitute placeholders for unsupported types
- Add tests covering dict and list content normalization for both sync and async routers

## Testing
- `pytest` *(fails: tests/test_timeout_cleanup.py::test_handler_process_killed_on_timeout[ClaudeCodeProxyHandler])*

------
https://chatgpt.com/codex/tasks/task_e_68c4e9f6bd288321b9b541899d63005b