### PR TITLE
feat: add CLI-specific errors and timeout tests

### DIFF
--- a/claude_code_client.py
+++ b/claude_code_client.py
@@ -2,7 +2,13 @@
 from typing import Dict, List, Optional
 from datetime import datetime
 from anthropic.types import Message, TextBlock, Usage
-from utils import run_subprocess, run_subprocess_async
+from utils import (
+    run_subprocess,
+    run_subprocess_async,
+    CLINotFoundError,
+    CLITimeoutError,
+    CLIError,
+)
 
 
 class ClaudeCodeClient:
@@ -83,7 +89,10 @@ class ClaudeCodeClient:
                     model_short = next((name for name in ["opus", "sonnet", "haiku"] if name in model.lower()), "sonnet")
                     cmd.extend(["--model", model_short])
         
-        return run_subprocess(cmd, prompt, "Claude Code")
+        try:
+            return run_subprocess(cmd, prompt, "Claude Code")
+        except (CLINotFoundError, CLITimeoutError, CLIError):
+            raise
     
     def create_message(
         self,
@@ -169,7 +178,10 @@ class ClaudeCodeClient:
                     )
                     cmd.extend(["--model", model_short])
 
-        response_text = await run_subprocess_async(cmd, prompt, "Claude Code")
+        try:
+            response_text = await run_subprocess_async(cmd, prompt, "Claude Code")
+        except (CLINotFoundError, CLITimeoutError, CLIError):
+            raise
         
         # Create a Message object that matches Anthropic's format
         message = Message(

--- a/codex_client.py
+++ b/codex_client.py
@@ -3,7 +3,13 @@ from typing import Dict, List, Optional
 from datetime import datetime
 from anthropic.types import Message, TextBlock, Usage
 from claude_code_client import ClaudeCodeClient
-from utils import run_subprocess, run_subprocess_async
+from utils import (
+    run_subprocess,
+    run_subprocess_async,
+    CLINotFoundError,
+    CLITimeoutError,
+    CLIError,
+)
 
 
 class CodexClient(ClaudeCodeClient):
@@ -32,7 +38,10 @@ class CodexClient(ClaudeCodeClient):
                         cmd.extend(["--model", name])
                         break
 
-        return run_subprocess(cmd, prompt, "Codex")
+        try:
+            return run_subprocess(cmd, prompt, "Codex")
+        except (CLINotFoundError, CLITimeoutError, CLIError):
+            raise
 
     def create_message(
         self,
@@ -84,7 +93,10 @@ class CodexClient(ClaudeCodeClient):
                         cmd.extend(["--model", name])
                         break
 
-        response_text = await run_subprocess_async(cmd, prompt, "Codex")
+        try:
+            response_text = await run_subprocess_async(cmd, prompt, "Codex")
+        except (CLINotFoundError, CLITimeoutError, CLIError):
+            raise
 
         message = Message(
             id="msg_codex_" + datetime.now().strftime("%Y%m%d%H%M%S"),

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,4 +1,12 @@
+import pytest
 import utils
+from utils import (
+    run_subprocess,
+    run_subprocess_async,
+    CLINotFoundError,
+    CLITimeoutError,
+    CLIError,
+)
 
 
 def test_is_all_nines_api_key_true_cases():
@@ -10,3 +18,40 @@ def test_is_all_nines_api_key_false_cases():
     assert not utils.is_all_nines_api_key("123456")
     assert not utils.is_all_nines_api_key("sk-ant-123")
     assert not utils.is_all_nines_api_key(None)
+
+
+def test_run_subprocess_not_found():
+    with pytest.raises(CLINotFoundError):
+        run_subprocess(["nonexistent_command"], "", "Test")
+
+
+def test_run_subprocess_timeout():
+    cmd = ["python", "-c", "import time; time.sleep(5)"]
+    with pytest.raises(CLITimeoutError):
+        run_subprocess(cmd, "", "Sleep", timeout=1)
+
+
+def test_run_subprocess_error():
+    cmd = ["python", "-c", "import sys; sys.exit(1)"]
+    with pytest.raises(CLIError):
+        run_subprocess(cmd, "", "Fail")
+
+
+@pytest.mark.asyncio
+async def test_run_subprocess_async_not_found():
+    with pytest.raises(CLINotFoundError):
+        await run_subprocess_async(["nonexistent_command"], "", "Test")
+
+
+@pytest.mark.asyncio
+async def test_run_subprocess_async_timeout():
+    cmd = ["python", "-c", "import time; time.sleep(5)"]
+    with pytest.raises(CLITimeoutError):
+        await run_subprocess_async(cmd, "", "Sleep", timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_run_subprocess_async_error():
+    cmd = ["python", "-c", "import sys; sys.exit(1)"]
+    with pytest.raises(CLIError):
+        await run_subprocess_async(cmd, "", "Fail")

--- a/tests/test_timeout_cleanup.py
+++ b/tests/test_timeout_cleanup.py
@@ -13,6 +13,7 @@ from claude_code_client import ClaudeCodeClient
 from codex_client import CodexClient
 from claude_code_proxy_handler import ClaudeCodeProxyHandler
 from codex_proxy_handler import CodexProxyHandler
+from utils import CLITimeoutError
 
 SCRIPT = Path(__file__).with_name("hanging_cli.py")
 
@@ -34,7 +35,7 @@ async def test_client_process_killed_on_timeout(client_cls, monkeypatch, tmp_pat
 
     monkeypatch.setattr(asyncio, "wait_for", _fast_timeout)
 
-    with pytest.raises(Exception):
+    with pytest.raises(CLITimeoutError):
         await client.acreate_message(
             messages=[{"role": "user", "content": "hi"}],
             model="test",
@@ -56,7 +57,7 @@ async def test_handler_process_killed_on_timeout(handler_cls, monkeypatch, tmp_p
 
     monkeypatch.setattr(asyncio, "wait_for", _fast_timeout)
 
-    with pytest.raises(Exception):
+    with pytest.raises(CLITimeoutError):
         await handler._call_claude_cli_async("prompt")
 
     pid = int(pid_file.read_text())


### PR DESCRIPTION
## Summary
- add custom CLIError exceptions for missing binaries, timeouts and failures
- surface CLI errors in Codex and Claude Code proxy handlers
- test subprocess failure modes and timeout cleanup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4eb94cdb883219124495033b4b398