### PR TITLE
Make allowed API paths configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,34 @@ curl https://api.anthropic.com/v1/messages \
   -d '{"model":"claude-3-sonnet-20240229","messages":[{"role":"user","content":"Hello"}],"max_tokens":50}'
 ```
 
+## Allowing Additional API Endpoints
+
+By default the proxy only permits a curated set of `/v1` API paths. The default
+configuration covers common Anthropic and OpenAI endpoints and falls back to
+allow any path under `/v1/`.
+
+To permit other endpoints you can either override the entire allow-list or
+extend it:
+
+- **Override** with a comma-separated list via the `ALLOWED_PATHS` environment
+  variable or `--allowed-paths` option:
+
+  ```bash
+  ALLOWED_PATHS="^/v1/my/endpoint$" python start_proxy.py
+  # or
+  python start_proxy.py --allowed-paths '^/v1/my/endpoint$'
+  ```
+
+- **Extend** the defaults by passing `--allowed-path` one or more times:
+
+  ```bash
+  python start_proxy.py --allowed-path '^/v1/beta$' --allowed-path '^/v1/other$'
+  ```
+
+Patterns are regular expressions that are combined at startup. This allows new
+API endpoints to be exposed through the proxy without modifying the source
+code.
+
 ### Option 2: Python Library
 
 ```python

--- a/start_proxy.py
+++ b/start_proxy.py
@@ -29,6 +29,9 @@ def main() -> None:
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", default="8080")
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging")
+    parser.add_argument("--allowed-paths", help="Comma-separated regex patterns to replace default allowed paths")
+    parser.add_argument("--allowed-path", action="append", default=[],
+                        help="Additional regex pattern to allow")
     args = parser.parse_args()
 
     ensure_dependencies()
@@ -36,6 +39,10 @@ def main() -> None:
     cmd = [sys.executable, "proxy_server.py", "--host", args.host, "--port", args.port]
     if args.verbose:
         cmd.append("--verbose")
+    if args.allowed_paths:
+        cmd.extend(["--allowed-paths", args.allowed_paths])
+    for pattern in args.allowed_path:
+        cmd.extend(["--allowed-path", pattern])
     subprocess.call(cmd)
 
 

--- a/test_proxy_server_paths.py
+++ b/test_proxy_server_paths.py
@@ -16,3 +16,20 @@ def test_openai_endpoints_allowed():
     for path in ["/v1/chat/completions", "/v1/completions"]:
         flow = DummyFlow(path)
         assert interceptor._validate_request(flow) is None, f"{path} should be allowed"
+
+
+def test_fallback_allows_new_paths():
+    interceptor = proxy_server.AIInterceptor()
+    flow = DummyFlow("/v1/new/endpoint")
+    assert interceptor._validate_request(flow) is None, "Fallback /v1/* pattern should allow new endpoint"
+
+
+def test_custom_paths_override():
+    original = proxy_server.ALLOWED_PATHS_REGEX
+    try:
+        proxy_server.ALLOWED_PATHS_REGEX = proxy_server.build_allowed_paths_regex([r'^/custom$'])
+        interceptor = proxy_server.AIInterceptor()
+        assert interceptor._validate_request(DummyFlow("/custom")) is None
+        assert interceptor._validate_request(DummyFlow("/v1/completions"))["error"]["type"] == "not_found"
+    finally:
+        proxy_server.ALLOWED_PATHS_REGEX = original


### PR DESCRIPTION
## Summary
- Extract allowed API paths into configurable list with /v1/* fallback
- Add CLI/env overrides for custom endpoint patterns
- Document how to extend or replace allowed endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4ed245a408321b1c12863a88e8ef8