### PR TITLE
Validate provider parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ message = client.messages.create(
 print(message.content[0].text)
 ```
 
+Valid values for `provider` are `"claude"`, `"anthropic"`, `"codex"`, and `"openai"`. Passing any other value to `create_client` or via the `AI_ROUTER_DEFAULT` environment variable will raise a `ValueError`.
+
 ## How It Works
 
 1. When you create a client with an API key that's all 9s (e.g., "999999999999"), the router automatically routes requests to the local Claude Code or Codex CLI

--- a/anthropic_router.py
+++ b/anthropic_router.py
@@ -168,6 +168,7 @@ def create_client(
     Args:
         api_key: API key for the selected provider.
         provider: "claude"/"anthropic" or "codex"/"openai". Overrides the default.
+            Unsupported values raise ``ValueError``.
         default_provider: Which provider to use if none is specified.
 
     Returns:
@@ -175,6 +176,13 @@ def create_client(
     """
     selected = provider or os.environ.get("AI_ROUTER_DEFAULT", default_provider)
     selected = selected.lower()
+
+    valid = {"claude", "anthropic", "codex", "openai"}
+    if selected not in valid:
+        raise ValueError(
+            f"Unsupported provider '{selected}'. Valid options: {', '.join(sorted(valid))}"
+        )
+
     if selected in {"codex", "openai"}:
         return OpenAIRouter(api_key=api_key)
     return AnthropicRouter(api_key=api_key)

--- a/test_codex_router.py
+++ b/test_codex_router.py
@@ -78,3 +78,14 @@ async def test_async_codex_stream_not_supported():
             messages=[{"role": "user", "content": "hi"}],
             stream=True,
         )
+
+
+def test_invalid_provider():
+    with pytest.raises(ValueError):
+        create_client(provider="invalid")
+
+
+def test_invalid_provider_env(monkeypatch):
+    monkeypatch.setenv("AI_ROUTER_DEFAULT", "invalid")
+    with pytest.raises(ValueError):
+        create_client()


### PR DESCRIPTION
## Summary
- validate `create_client` provider against `claude`, `anthropic`, `codex` and `openai`
- raise `ValueError` for unsupported providers and document valid options
- test invalid provider names and environment default

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4f79d666c83218d80fb9ee754d817