### PR TITLE
Handle empty OpenAI streaming responses

### DIFF
--- a/openai_router.py
+++ b/openai_router.py
@@ -113,6 +113,8 @@ class MessagesRouter:
                             text_parts.append(part)
                     if getattr(event, "usage", None):
                         usage = event.usage
+                if first_event is None:
+                    raise RuntimeError("No chunks were received from the streaming response")
                 final = first_event
                 text = "".join(text_parts)
                 usage = usage or getattr(final, "usage", None)
@@ -224,6 +226,8 @@ class AsyncMessagesRouter:
                             text_parts.append(part)
                     if getattr(event, "usage", None):
                         usage = event.usage
+                if first_event is None:
+                    raise RuntimeError("No chunks were received from the streaming response")
                 final = first_event
                 text = "".join(text_parts)
                 usage = usage or getattr(final, "usage", None)

--- a/test_openai_router.py
+++ b/test_openai_router.py
@@ -140,6 +140,34 @@ def test_stream_passed_to_openai(monkeypatch):
     assert msg.content[0].text == "hello"
 
 
+def test_empty_stream_raises_error(monkeypatch):
+    class MockStreamResponse:
+        def __iter__(self):
+            return iter([])
+
+    class MockChatCompletions:
+        def create(self, **kwargs):
+            return MockStreamResponse()
+
+    class MockChat:
+        def __init__(self):
+            self.completions = MockChatCompletions()
+
+    class MockClient:
+        def __init__(self, *args, **kwargs):
+            self.chat = MockChat()
+
+    monkeypatch.setattr(openai_router, "OpenAI", lambda api_key=None: MockClient())
+    router = OpenAIRouter(api_key="real-key")
+    with pytest.raises(RuntimeError, match="No chunks were received"):
+        router.messages.create(
+            model="gpt-4",
+            max_tokens=5,
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+        )
+
+
 def test_sampling_params_and_metadata_passed_to_openai(monkeypatch):
     captured = {}
 
@@ -239,6 +267,43 @@ def test_async_stream_passed_to_openai(monkeypatch):
     msg = asyncio.run(run())
     assert captured["stream"] is True
     assert msg.content[0].text == "hello"
+
+
+def test_async_empty_stream_raises_error(monkeypatch):
+    class MockStreamResponse:
+        def __aiter__(self):
+            async def gen():
+                if False:
+                    yield None
+            return gen()
+
+    class MockChatCompletions:
+        async def create(self, **kwargs):
+            return MockStreamResponse()
+
+    class MockChat:
+        def __init__(self):
+            self.completions = MockChatCompletions()
+
+    class MockClient:
+        def __init__(self, *args, **kwargs):
+            self.chat = MockChat()
+
+    monkeypatch.setattr(openai_router, "AsyncOpenAI", lambda api_key=None: MockClient())
+    router = AsyncOpenAIRouter(api_key="real-key")
+
+    async def run():
+        with pytest.raises(RuntimeError, match="No chunks were received"):
+            await router.messages.create(
+                model="gpt-4",
+                max_tokens=5,
+                messages=[{"role": "user", "content": "hi"}],
+                stream=True,
+            )
+
+    import asyncio
+
+    asyncio.run(run())
 
 
 def test_async_sampling_params_and_metadata_passed_to_openai(monkeypatch):


### PR DESCRIPTION
## Summary
- ensure MessagesRouter and AsyncMessagesRouter validate that streaming completions yield at least one chunk
- raise a clear RuntimeError if no chunks are received
- add synchronous and asynchronous unit tests for empty streaming responses

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4f869b9a883218cc0dc4388fe0bd5