### PR TITLE
Handle proxy server failures

### DIFF
--- a/start_proxy.py
+++ b/start_proxy.py
@@ -43,7 +43,11 @@ def main() -> None:
         cmd.extend(["--allowed-paths", args.allowed_paths])
     for pattern in args.allowed_path:
         cmd.extend(["--allowed-path", pattern])
-    subprocess.call(cmd)
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as exc:
+        print(f"Proxy server exited with status {exc.returncode}", file=sys.stderr)
+        sys.exit(exc.returncode)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use `subprocess.check_call` in the proxy launcher
- surface `CalledProcessError` with a clear exit code

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4f8ddba2883219e1823078837dfd1