### PR TITLE
Pass allowed-paths regex into AIInterceptor

### DIFF
--- a/start_proxy.py
+++ b/start_proxy.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 """Cross-platform launcher for Anthropic API proxy server."""
 import argparse
+import asyncio
+import logging
 import shutil
-import subprocess
 import sys
+
+import proxy_server
 
 
 def command_exists(cmd: str) -> bool:
@@ -19,6 +22,8 @@ def ensure_dependencies() -> None:
     try:
         import mitmproxy  # noqa: F401
     except Exception:
+        import subprocess
+
         print("Installing Python dependencies...")
         subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"])
 
@@ -27,27 +32,48 @@ def ensure_dependencies() -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Anthropic API Proxy Server Launcher")
     parser.add_argument("--host", default="127.0.0.1")
-    parser.add_argument("--port", default="8080")
+    parser.add_argument("--port", type=int, default=8080)
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging")
-    parser.add_argument("--allowed-paths", help="Comma-separated regex patterns to replace default allowed paths")
-    parser.add_argument("--allowed-path", action="append", default=[],
-                        help="Additional regex pattern to allow")
+    parser.add_argument(
+        "--allowed-paths",
+        help="Comma-separated regex patterns to replace default allowed paths",
+    )
+    parser.add_argument(
+        "--allowed-path",
+        action="append",
+        default=[],
+        help="Additional regex pattern to allow",
+    )
     args = parser.parse_args()
 
     ensure_dependencies()
 
-    cmd = [sys.executable, "proxy_server.py", "--host", args.host, "--port", args.port]
     if args.verbose:
-        cmd.append("--verbose")
-    if args.allowed_paths:
-        cmd.extend(["--allowed-paths", args.allowed_paths])
-    for pattern in args.allowed_path:
-        cmd.extend(["--allowed-path", pattern])
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    override = args.allowed_paths
+    if override:
+        patterns = [p.strip() for p in override.split(",") if p.strip()]
+    else:
+        patterns = list(proxy_server.DEFAULT_ALLOWED_PATH_PATTERNS)
+    if args.allowed_path:
+        patterns.extend(args.allowed_path)
+    allowed_paths_regex = proxy_server.build_allowed_paths_regex(patterns)
+
     try:
-        subprocess.check_call(cmd)
-    except subprocess.CalledProcessError as exc:
-        print(f"Proxy server exited with status {exc.returncode}", file=sys.stderr)
-        sys.exit(exc.returncode)
+        asyncio.run(
+            proxy_server.start_proxy(
+                args.host,
+                args.port,
+                allowed_paths_regex=allowed_paths_regex,
+            )
+        )
+    except KeyboardInterrupt:
+        print("\nProxy server stopped.")
+        sys.exit(0)
+    except Exception as exc:
+        print(f"Proxy server error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/test_proxy_server_codex.py
+++ b/test_proxy_server_codex.py
@@ -2,6 +2,10 @@ import json
 import pytest
 import proxy_server
 
+DEFAULT_REGEX = proxy_server.build_allowed_paths_regex(
+    proxy_server.DEFAULT_ALLOWED_PATH_PATTERNS
+)
+
 
 class DummyRequest:
     def __init__(self, path, method="POST", content=b"{}"):
@@ -18,7 +22,7 @@ class DummyFlow:
 
 @pytest.mark.asyncio
 async def test_chat_completions_success(monkeypatch):
-    interceptor = proxy_server.AIInterceptor()
+    interceptor = proxy_server.AIInterceptor(DEFAULT_REGEX)
 
     async def mock_messages(data, method):
         return {"id": "1"}
@@ -33,7 +37,7 @@ async def test_chat_completions_success(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_chat_completions_not_found(monkeypatch):
-    interceptor = proxy_server.AIInterceptor()
+    interceptor = proxy_server.AIInterceptor(DEFAULT_REGEX)
 
     async def mock_messages(data, method):
         return {"error": {"type": "not_found_error", "message": "missing"}}
@@ -48,7 +52,7 @@ async def test_chat_completions_not_found(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_completions_success(monkeypatch):
-    interceptor = proxy_server.AIInterceptor()
+    interceptor = proxy_server.AIInterceptor(DEFAULT_REGEX)
 
     async def mock_complete(data, method):
         return {"completion": "ok"}
@@ -63,7 +67,7 @@ async def test_completions_success(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_completions_invalid(monkeypatch):
-    interceptor = proxy_server.AIInterceptor()
+    interceptor = proxy_server.AIInterceptor(DEFAULT_REGEX)
 
     async def mock_complete(data, method):
         return {"error": {"type": "invalid_request_error", "message": "bad"}}

--- a/test_proxy_server_paths.py
+++ b/test_proxy_server_paths.py
@@ -1,5 +1,9 @@
 import proxy_server
 
+DEFAULT_REGEX = proxy_server.build_allowed_paths_regex(
+    proxy_server.DEFAULT_ALLOWED_PATH_PATTERNS
+)
+
 class DummyRequest:
     def __init__(self, path, method="POST", content=b""):
         self.path = path
@@ -12,24 +16,23 @@ class DummyFlow:
 
 
 def test_openai_endpoints_allowed():
-    interceptor = proxy_server.AIInterceptor()
+    interceptor = proxy_server.AIInterceptor(DEFAULT_REGEX)
     for path in ["/v1/chat/completions", "/v1/completions"]:
         flow = DummyFlow(path)
         assert interceptor._validate_request(flow) is None, f"{path} should be allowed"
 
 
 def test_fallback_allows_new_paths():
-    interceptor = proxy_server.AIInterceptor()
+    interceptor = proxy_server.AIInterceptor(DEFAULT_REGEX)
     flow = DummyFlow("/v1/new/endpoint")
     assert interceptor._validate_request(flow) is None, "Fallback /v1/* pattern should allow new endpoint"
 
 
 def test_custom_paths_override():
-    original = proxy_server.ALLOWED_PATHS_REGEX
-    try:
-        proxy_server.ALLOWED_PATHS_REGEX = proxy_server.build_allowed_paths_regex([r'^/custom$'])
-        interceptor = proxy_server.AIInterceptor()
-        assert interceptor._validate_request(DummyFlow("/custom")) is None
-        assert interceptor._validate_request(DummyFlow("/v1/completions"))["error"]["type"] == "not_found"
-    finally:
-        proxy_server.ALLOWED_PATHS_REGEX = original
+    custom_regex = proxy_server.build_allowed_paths_regex([r"^/custom$"])
+    interceptor = proxy_server.AIInterceptor(custom_regex)
+    assert interceptor._validate_request(DummyFlow("/custom")) is None
+    assert (
+        interceptor._validate_request(DummyFlow("/v1/completions"))["error"]["type"]
+        == "not_found"
+    )


### PR DESCRIPTION
## Summary
- construct allowed-paths regex in main and pass it to `AIInterceptor`
- store allowed-paths regex on `AIInterceptor` instances rather than relying on a global
- teach `start_proxy.py` and tests to compile and provide the regex explicitly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4fb6b7514832185e7b884752f9522