### PR TITLE
Remove unsupported top_k from OpenAI calls

### DIFF
--- a/openai_router.py
+++ b/openai_router.py
@@ -93,7 +93,7 @@ class MessagesRouter:
                 max_tokens=max_tokens,
                 temperature=temperature if temperature is not NOT_GIVEN else None,
                 top_p=top_p if top_p is not NOT_GIVEN else None,
-                top_k=top_k if top_k is not NOT_GIVEN else None,
+                # top_k is not supported by the OpenAI API; ignore it when routing here
                 stop=stop_sequences if stop_sequences is not NOT_GIVEN else None,
                 stream=stream if stream is not NOT_GIVEN else False,
                 metadata=metadata if metadata is not NOT_GIVEN else None,
@@ -206,7 +206,7 @@ class AsyncMessagesRouter:
                 max_tokens=max_tokens,
                 temperature=temperature if temperature is not NOT_GIVEN else None,
                 top_p=top_p if top_p is not NOT_GIVEN else None,
-                top_k=top_k if top_k is not NOT_GIVEN else None,
+                # top_k is not supported by the OpenAI API; ignore it when routing here
                 stop=stop_sequences if stop_sequences is not NOT_GIVEN else None,
                 stream=stream if stream is not NOT_GIVEN else False,
                 metadata=metadata if metadata is not NOT_GIVEN else None,

--- a/test_openai_router.py
+++ b/test_openai_router.py
@@ -210,7 +210,7 @@ def test_sampling_params_and_metadata_passed_to_openai(monkeypatch):
         metadata={"foo": "bar"},
     )
     assert captured["top_p"] == 0.9
-    assert captured["top_k"] == 40
+    assert "top_k" not in captured
     assert captured["metadata"] == {"foo": "bar"}
 
 
@@ -354,7 +354,7 @@ def test_async_sampling_params_and_metadata_passed_to_openai(monkeypatch):
 
     asyncio.run(run())
     assert captured["top_p"] == 0.9
-    assert captured["top_k"] == 40
+    assert "top_k" not in captured
     assert captured["metadata"] == {"foo": "bar"}
 
 


### PR DESCRIPTION
## Summary
- Ignore top_k when routing to the OpenAI API
- Adjust tests to ensure top_k is not sent to OpenAI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c50199293083218a91618cf5c5c47e