### PR TITLE
Warn when Codex CLI missing during proxy startup

### DIFF
--- a/start_proxy.py
+++ b/start_proxy.py
@@ -18,6 +18,8 @@ def ensure_dependencies() -> None:
     """Verify required dependencies are available, installing if needed."""
     if not command_exists("claude"):
         print("⚠️  Warning: Claude Code CLI not found; local routing will fail.")
+    if not command_exists("codex"):
+        print("⚠️  Warning: Codex CLI not found; codex routing will fail.")
 
     try:
         import mitmproxy  # noqa: F401


### PR DESCRIPTION
## Summary
- warn if Codex CLI isn't installed when launching proxy

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c77545856883218778115bf70d457a