### PR TITLE
Ensure utility imports include asyncio and subprocess

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,6 @@
 import asyncio
 import subprocess
-from typing import List, Optional
+from typing import Optional, List
 
 
 class CLIError(Exception):


### PR DESCRIPTION
## Summary
- Reorder typing import and ensure `utils.py` explicitly imports `asyncio`, `subprocess`, and typing helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c81e08b8708321b1003ae35a5d74cd