### PR TITLE
Lazy-load proxy_server after dependency check

### DIFF
--- a/start_proxy.py
+++ b/start_proxy.py
@@ -6,9 +6,6 @@ import logging
 import shutil
 import sys
 
-import proxy_server
-
-
 def command_exists(cmd: str) -> bool:
     """Check if a command exists on PATH."""
     return shutil.which(cmd) is not None
@@ -49,6 +46,8 @@ def main() -> None:
     args = parser.parse_args()
 
     ensure_dependencies()
+
+    import proxy_server
 
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION
## Summary
- Remove top-level proxy_server import
- Import proxy_server inside `main` after verifying dependencies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c81e00ed58832194c6fe92c10b3bd5