### PR TITLE
Add pytest dependencies to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ anthropic>=0.18.0
 openai>=1.0.0
 mitmproxy>=10.0.0
 cryptography>=41.0.0
+pytest>=7.4.0
+pytest-asyncio>=0.21.0
+requests>=2.31.0


### PR DESCRIPTION
## Summary
- add pytest, pytest-asyncio, and requests to the requirements list so the async suites and proxy tests can run

## Testing
- pip install -r requirements.txt
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d15e5ce67883218f7ad67fd6bc0bb9